### PR TITLE
Fix interior mutability difficulty using HashMaps

### DIFF
--- a/exa-language-server/src/bin/main.rs
+++ b/exa-language-server/src/bin/main.rs
@@ -1,11 +1,13 @@
 use std::collections::HashMap;
 use std::error::Error;
+use std::sync::{Arc, RwLock};
 
 use lsp_server::{Connection, Message, Notification, Request, RequestId};
 use lsp_text_document::FullTextDocument;
 use lsp_types::notification::{DidChangeTextDocument, DidCloseTextDocument, DidOpenTextDocument};
 use lsp_types::{
-    InitializedParams, ServerCapabilities, TextDocumentSyncCapability, TextDocumentSyncKind, Url, Position,
+    InitializedParams, Position, ServerCapabilities, TextDocumentSyncCapability,
+    TextDocumentSyncKind, Url,
 };
 
 use exa_language_server::documents::Document;
@@ -36,7 +38,7 @@ fn handle_messages(
     connection: Connection,
     init_params: serde_json::Value,
 ) -> Result<(), Box<dyn Error + Sync + Send>> {
-    let mut documents: HashMap<Url, Document> = HashMap::new();
+    let mut documents: HashMap<Url, Arc<RwLock<Document>>> = HashMap::new();
     let _init_params: InitializedParams = serde_json::from_value(init_params).unwrap();
     for msg in &connection.receiver {
         eprintln!("received message: {:?}", msg);
@@ -63,11 +65,11 @@ fn handle_messages(
                         if !documents.contains_key(&params.text_document.uri) {
                             documents.insert(
                                 params.text_document.uri.clone(),
-                                Document::new(
+                                Arc::new(RwLock::new(Document::new(
                                     params.text_document.uri,
                                     params.text_document.version.into(),
-                                    params.text_document.text
-                                ),
+                                    params.text_document.text,
+                                ))),
                             );
                         }
                         eprintln!("open documents: {:?} -> {:?}", prev_size, documents.len());
@@ -79,21 +81,31 @@ fn handle_messages(
                 {
                     Ok(params) => {
                         eprintln!("DidChangeTextDocument -> {:?}", params);
+                        //let document: &mut Document = documents.get(&params.text_document.uri).unwrap();
                         let document = documents.get(&params.text_document.uri).unwrap();
                         let mut text_document = FullTextDocument::new(
-                            document.uri.clone(), String::from("exalang"), document.version, document.text.clone()
+                            document.read().unwrap().uri.clone(),
+                            String::from("exalang"),
+                            document.read().unwrap().version,
+                            document.read().unwrap().text.clone(),
                         );
                         for change_event in params.content_changes {
                             let range = change_event.range.unwrap();
                             let start_offset = text_document.offset_at(range.start);
                             let end_offset = text_document.offset_at(range.end);
-                            let (start_byte, old_end_byte) = text_document.transform_offset_to_byte_offset(
-                                start_offset,
-                                end_offset
+                            let (start_byte, old_end_byte) = text_document
+                                .transform_offset_to_byte_offset(start_offset, end_offset);
+                            text_document.update(
+                                vec![change_event.clone()],
+                                params.text_document.version.into(),
                             );
-                            text_document.update(vec![change_event.clone()], params.text_document.version.into());
-                            let new_end_byte = start_byte + change_event.text.chars().fold(0, |acc, c| acc + c.len_utf8());
-                            let new_end_position = text_document.position_at(new_end_byte.try_into().unwrap());
+                            let new_end_byte = start_byte
+                                + change_event
+                                    .text
+                                    .chars()
+                                    .fold(0, |acc, c| acc + c.len_utf8());
+                            let new_end_position =
+                                text_document.position_at(new_end_byte.try_into().unwrap());
                             /*
                              *                  8
                              *          fn test(|) {}
@@ -118,9 +130,9 @@ fn handle_messages(
                                 new_end_byte,
                                 start_position: position_to_point(&range.start),
                                 old_end_position: position_to_point(&range.end),
-                                new_end_position: position_to_point(&new_end_position)
+                                new_end_position: position_to_point(&new_end_position),
                             };
-                            document.tree.edit(&input_edit);
+                            document.write().unwrap().tree.edit(&input_edit);
                         }
                         continue;
                     }


### PR DESCRIPTION
Interior mutability with HashMaps is difficult. You need to use an `Arc` which wraps some sort of access lock (`Mutex` or `RwLock` or something) since Rust want's everything to be thread-safe.