### PR TITLE
Fix borrow-checker issues

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -98,7 +98,7 @@ fn handle_messages(
                             .unwrap();
                         eprintln!("{:?}", node.to_sexp());
 
-                        match document.resolve_documentation(documentation, node) {
+                        match Document::resolve_documentation(documentation.clone(), node) {
                             Some(result) => {
                                 // Construct the result field of the Response.
                                 let hover = Hover {

--- a/src/document.rs
+++ b/src/document.rs
@@ -25,7 +25,6 @@ impl Document {
     }
 
     pub fn resolve_documentation(
-        &mut self,
         documentation: DocumentationMap,
         node: Node,
     ) -> Option<String> {


### PR DESCRIPTION
`resolve_documentation` never used `self`, so I removed that, then I just cloned `documentation`. This may be inefficient, but should work for now.