### PR TITLE
Draft: Replace the `lsp-text-document` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,6 @@ name = "exa-language-server"
 version = "0.1.0"
 dependencies = [
  "lsp-server",
- "lsp-text-document",
  "lsp-types",
  "rand",
  "ropey",
@@ -308,15 +307,6 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "lsp-text-document"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339c9ae1d20020935ea9a75ea5e9e81489bf7986ba41d44163bf7e8273edcbb5"
-dependencies = [
- "lsp-types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,10 @@ name = "exa-language-server"
 version = "0.1.0"
 dependencies = [
  "lsp-server",
+ "lsp-text-document",
  "lsp-types",
+ "rand",
+ "ropey",
  "serde",
  "serde_json",
  "tree-sitter",
@@ -308,6 +311,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lsp-text-document"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339c9ae1d20020935ea9a75ea5e9e81489bf7986ba41d44163bf7e8273edcbb5"
+dependencies = [
+ "lsp-types",
+]
+
+[[package]]
 name = "lsp-types"
 version = "0.84.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,6 +377,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,6 +398,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -418,6 +466,16 @@ name = "regex-syntax"
 version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+
+[[package]]
+name = "ropey"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd22239fafefc42138ca5da064f3c17726a80d2379d817a3521240e78dd0064"
+dependencies = [
+ "smallvec",
+ "str_indices",
+]
 
 [[package]]
 name = "rustc-hash"
@@ -494,6 +552,18 @@ name = "smallbitvec"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75ce4f9dc4a41b4c3476cc925f1efb11b66df373a8fde5d4b8915fa91b5d995e"
+
+[[package]]
+name = "smallvec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
+
+[[package]]
+name = "str_indices"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d9199fa80c817e074620be84374a520062ebac833f358d74b37060ce4a0f2c0"
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,6 @@ name = "exa-language-server"
 version = "0.1.0"
 dependencies = [
  "lsp-server",
- "lsp-text-document",
  "lsp-types",
  "serde",
  "serde_json",
@@ -306,15 +305,6 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "lsp-text-document"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339c9ae1d20020935ea9a75ea5e9e81489bf7986ba41d44163bf7e8273edcbb5"
-dependencies = [
- "lsp-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ tree-sitter = "~0.20.0"
 tree-sitter-highlight = "~0.20.0"
 
 [dev-dependencies]
-lsp-text-document = "~0.2.0"
 rand = "*"
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,6 @@ version = "0.1.0"
 
 [dependencies]
 lsp-server = "~0.5.0"
-lsp-text-document = "~0.2.0"
-# NOTE: You'll get compiler errors if this version number is different than
-#       the version used by `lsp-text-document`.
 lsp-types = "~0.84.0"
 serde = "~1.0.0"
 serde_json = "~1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,15 @@ version = "0.1.0"
 [dependencies]
 lsp-server = "~0.5.0"
 lsp-types = "~0.84.0"
+ropey = "~1.5.0"
 serde = "~1.0.0"
 serde_json = "~1.0.0"
 tree-sitter = "~0.20.0"
 tree-sitter-highlight = "~0.20.0"
+
+[dev-dependencies]
+lsp-text-document = "~0.2.0"
+rand = "*"
 
 [workspace]
 members = ["tree-sitter-exa"]

--- a/src/document.rs
+++ b/src/document.rs
@@ -172,7 +172,6 @@ impl Document {
 
 #[cfg(test)]
 mod test {
-    use lsp_text_document::FullTextDocument;
     use lsp_types::{Position, Url};
     use std::path::Path;
 
@@ -218,15 +217,6 @@ mod test {
     /// "works ✅" ------------------------- 07 chars, 09 bytes
     /// ```
     static DOCTEXT2: &str = "This 📃\njust makes\u{2009}sure that\ne\u{0300}verythìng\nworks ✅";
-
-    fn make_test_oracle(doc: &Document) -> FullTextDocument {
-        FullTextDocument::new(
-            doc.uri.clone(),
-            String::from("exalang"),
-            doc.version.clone(),
-            doc.text.clone(),
-        )
-    }
 
     fn make_doc(text: &str) -> Document {
         //For linux/macos/*bsd/etc...

--- a/src/document.rs
+++ b/src/document.rs
@@ -346,18 +346,20 @@ mod test {
     }
 
     #[test]
-    fn offset_at_and_position_at_are_reciprocol() {
-        let doc = make_doc(DOCTEXT1);
-        let mut oracle = make_test_oracle(&doc);
+    fn offset_at_and_position_at_are_reciprocal() {
+        let cases: Vec<usize> = vec![0, 31, 38, 46, 47, 52, 53, 64, 65];
 
-        let offsets: Vec<usize> = vec![8, 1, 38, 65];
+        let doc1 = make_doc(DOCTEXT1);
+        let doc2 = make_doc(DOCTEXT2);
 
-        for offset in offsets {
-            let expect_position = oracle.position_at(offset.try_into().unwrap());
-            assert_eq!(
-                doc.offset_at(doc.position_at(offset.clone())),
-                oracle.offset_at(expect_position)
-            );
+        for offset in cases {
+            let actual1 = doc1.offset_at(doc1.position_at(offset));
+            let expected1 = offset.clamp(0, doc1.buffer.len_chars());
+            assert_eq!(actual1, expected1, "Calculated {} from {} in DOCTEXT1; expected {}", actual1, offset, expected1);
+
+            let actual2 = doc2.offset_at(doc2.position_at(offset));
+            let expected2 = offset.clamp(0, doc2.buffer.len_chars());
+            assert_eq!(actual2, expected2, "Calculated {} from {} in DOCTEXT2; expected {}", actual2, offset, expected2);
         }
     }
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -103,7 +103,7 @@ impl Document {
         }
 
         let documentation_items = documentation
-            .get(&String::from(kind))
+            .get(kind)
             .unwrap()
             .read()
             .unwrap();

--- a/src/document.rs
+++ b/src/document.rs
@@ -152,6 +152,8 @@ impl Document {
              *          fn test(|) {}
              *
              *          fn test(a: u32|) {}
+             *                        |- The cursor is shifted to the right
+             *                        |  by the text addition.
              *                        14
              * Change:
              *  text: "a: u32"
@@ -164,6 +166,30 @@ impl Document {
              *      line: 0
              *      character: 8
              *  range_len: 0
+             *
+             *                  8      14
+             *                  |------|- Highlighted text
+             *                  |      |  (before copy-pasting "z: char").
+             *          fn test(|a: u32|) {}
+             *
+             *          fn test(z: char) {}
+             * Change:
+             *  text: "z: char"
+             *    length: 7
+             *  range:
+             *    start:
+             *      line: 0
+             *      character: 8
+             *    end:
+             *      line: 0
+             *      character: 14
+             *  range_len: 6
+             *
+             * NOTES:
+             *  * The `range` is the Range of the text to overwrite with
+             *    the provided `text`.
+             *  * The `range.start` and `range.end` are indicative of the
+             *    highlighted text area BEFORE the change is made.
              */
             let input_edit = InputEdit {
                 start_byte,

--- a/src/document.rs
+++ b/src/document.rs
@@ -102,11 +102,7 @@ impl Document {
             return None;
         }
 
-        let documentation_items = documentation
-            .get(kind)
-            .unwrap()
-            .read()
-            .unwrap();
+        let documentation_items = documentation.get(kind).unwrap().read().unwrap();
 
         if documentation_items.len() == 1 {
             return Some(documentation_items[0].description.clone());

--- a/src/document.rs
+++ b/src/document.rs
@@ -93,8 +93,8 @@ impl Document {
         }
     }
 
-    /// Resolve the [`DocumentationItem`](crate::documentation::DocumentationItem)
-    /// as a [`String`] for the given [`Node`].
+    /// Resolve a [`DocumentationItem`](crate::documentation::DocumentationItem) description for
+    /// the given [`Node`].
     pub fn resolve_documentation(documentation: DocumentationMap, node: Node) -> Option<String> {
         let kind = node.kind();
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -141,7 +141,8 @@ impl Document {
             let end_offset = self.offset_at(range.end);
             let (start_byte, old_end_byte) =
                 self.from_char_to_byte_offset(start_offset, end_offset);
-            todo!("apply this TextDocumentContentChangeEvent (change_event) to the `ropey` buffer");
+            self.buffer.remove(start_offset..end_offset);
+            self.buffer.insert(start_offset, change_event.text.as_str());
             let new_end_byte = start_byte
                 + change_event
                     .text
@@ -178,7 +179,7 @@ impl Document {
         }
         // Finalize update.
         self.version = version;
-        self.text = todo!("update text content from `ropey` buffer");
+        self.text = self.buffer.to_string();
         self.tree = self
             .parser
             .parse(self.text.clone(), Some(&self.tree))

--- a/src/document.rs
+++ b/src/document.rs
@@ -243,7 +243,7 @@ mod test {
     ///                                     36b
     ///                                     36c
     /// ```
-    static DOCTEST3: &str = "A document with a single line. ¯\\_(ツ)_/¯";
+    static DOCTEXT3: &str = "A document with a single line. ¯\\_(ツ)_/¯";
 
     fn make_doc(text: &str) -> Document {
         //For linux/macos/*bsd/etc...
@@ -283,7 +283,7 @@ mod test {
         let doc2 = make_doc(DOCTEXT2);
         let expected2: Vec<usize> = vec![0, 7, 7, 31, 47, 47, 46, 47, 47, 47];
 
-        let doc3 = make_doc(DOCTEST3);
+        let doc3 = make_doc(DOCTEXT3);
         let expected3: Vec<usize> = vec![0, 39, 40, 40, 40, 40, 40, 40, 40, 40];
 
         // DOCTEXT1
@@ -347,7 +347,7 @@ mod test {
             Position::new(3, 7),
         ];
 
-        let doc3 = make_doc(DOCTEST3);
+        let doc3 = make_doc(DOCTEXT3);
         let expected3: Vec<Position> = vec![
             Position::new(0, 0),
             Position::new(0, 31),
@@ -397,7 +397,7 @@ mod test {
 
         let doc1 = make_doc(DOCTEXT1);
         let doc2 = make_doc(DOCTEXT2);
-        let doc3 = make_doc(DOCTEST3);
+        let doc3 = make_doc(DOCTEXT3);
 
         for offset in cases {
             let actual1 = doc1.offset_at(doc1.position_at(offset));

--- a/src/document.rs
+++ b/src/document.rs
@@ -202,7 +202,7 @@ mod test {
     static DOCTEXT1: &str = "This document\njust makes sure that\neverything\nworks as it should.";
     // ⚠ WARNING ⚠ changing this value means you need to recalculate the expected values below!
     /// 47 characters, 56 bytes \
-    /// Character offsets at the start of each line: `[0, 7, 28, 41]`
+    /// Character offsets at the start of each line: `[0, 7, 28, 40]`
     /// ```text
     ///  1c -|--|
     ///  4b -|--|

--- a/src/document.rs
+++ b/src/document.rs
@@ -431,13 +431,13 @@ mod test {
     fn char_to_byte_offset_works() {
         // All cases are character offsets from DOCTEXT2.
         let cases: Vec<(usize, usize)> = vec![
-            (0, 0), // ""
-            (5, 6), // "📃"
+            (0, 0),   // ""
+            (5, 6),   // "📃"
             (12, 22), // "makes\u{2009}sure"
             (28, 28), // ""
             (28, 40), // "e\u{0300}verythìng\n"
             (46, 47), // "✅"
-            (0, 47), // all text
+            (0, 47),  // all text
         ];
 
         let doc2 = make_doc(DOCTEXT2);

--- a/src/document.rs
+++ b/src/document.rs
@@ -93,6 +93,8 @@ impl Document {
         }
     }
 
+    /// Resolve the [`DocumentationItem`](crate::documentation::DocumentationItem)
+    /// as a [`String`] for the given [`Node`].
     pub fn resolve_documentation(documentation: DocumentationMap, node: Node) -> Option<String> {
         let kind = node.kind();
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -52,7 +52,16 @@ impl Document {
 
     /// [Position] at the given (character) offset.
     pub fn position_at(&self, offset: usize) -> Position {
-        todo!()
+        let mut line_num: u32 = 0;
+        let mut offset = offset;
+        for line in self.text.split("\n").collect::<Vec<&str>>() {
+            if (offset as isize - ((line.len() as isize) + 1)) < 0 {
+                break;
+            }
+            line_num += 1;
+            offset -= line.len() + 1; // include the \n that we split on
+        }
+        Position { line: line_num, character: offset as u32 }
     }
 
     pub fn resolve_documentation(documentation: DocumentationMap, node: Node) -> Option<String> {
@@ -190,4 +199,16 @@ works as it should."#,
         }
     }
 
+    #[test]
+    fn position_at_works() {
+        let pos_offset_pairs: Vec<(Position, usize)> = vec![
+            (Position::new(0, 0), 0),
+            (Position::new(2, 3), 38),  // 14 + 21 + 3 = 38
+            (Position::new(3, 19), 65), // 14 + 21 + 11 + 19 = 65
+        ];
+
+        for (expected, offset) in pos_offset_pairs {
+            assert_eq!(make_doc().position_at(offset), expected);
+        }
+    }
 }

--- a/src/document.rs
+++ b/src/document.rs
@@ -211,4 +211,13 @@ works as it should."#,
             assert_eq!(make_doc().position_at(offset), expected);
         }
     }
+
+    #[test]
+    fn offset_at_and_position_at_are_reciprocol() {
+        let doc = make_doc();
+        assert_eq!(doc.offset_at(doc.position_at(8)), 8);
+        assert_eq!(doc.offset_at(doc.position_at(1)), 1);
+        assert_eq!(doc.offset_at(doc.position_at(38)), 38);
+        assert_eq!(doc.offset_at(doc.position_at(65)), 65);
+    }
 }

--- a/src/documentation.rs
+++ b/src/documentation.rs
@@ -38,6 +38,7 @@ struct Documentation {
     pub documentation: Vec<DocumentationItem>,
 }
 
+/// No [`Vec<DocumentationItem>`] will ever have zero length. See [`read_from_file`].
 pub type DocumentationMap = HashMap<String, Arc<RwLock<Vec<DocumentationItem>>>>;
 
 pub fn read_from_file<P: AsRef<Path>>(path: P) -> Result<DocumentationMap, Box<dyn Error>> {

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,4 +1,3 @@
-use lsp_text_document::FullTextDocument;
 use tree_sitter::{Node, Range};
 
 use crate::{document::Document, location::position_to_point};
@@ -12,12 +11,6 @@ pub fn get_own_text_pointrange(node: &Node, document: &Document) -> Range {
         return node.range();
     }
 
-    let mut full_text_doc = FullTextDocument::new(
-        document.uri.clone(),
-        String::from("exalang"),
-        document.version,
-        document.text.clone(),
-    );
     let child_start_byte = node.child(0).unwrap().start_byte();
     let own_text =
         String::from_utf8(document.text.as_bytes()[node.start_byte()..child_start_byte].to_vec())
@@ -27,6 +20,6 @@ pub fn get_own_text_pointrange(node: &Node, document: &Document) -> Range {
         start_byte: node.start_byte(),
         end_byte,
         start_point: node.start_position(),
-        end_point: position_to_point(&full_text_doc.position_at(end_byte.try_into().unwrap())),
+        end_point: position_to_point(&document.position_at(end_byte)),
     };
 }


### PR DESCRIPTION
All points of interest are marked with `todo` macros.

Feel free to adjust mutability and/or borrowing as necessary.

Let me know if you are interested in authoring unit tests and I can provide some `TextDocumentContentChangeEvent`s that you can pass to `Document.update`.

- [ ] Run Clippy